### PR TITLE
ignore uppercase letters for bibtex entry types

### DIFF
--- a/refs_vault_gen.py
+++ b/refs_vault_gen.py
@@ -11,7 +11,6 @@ from collections import OrderedDict, defaultdict
 from dataclasses import dataclass,asdict
 import unicodedata
 
-
 import yaml
 import chevron # implementation of mustache templating
 import biblib.bib
@@ -367,8 +366,8 @@ def load_bibtex_raw(filename : str) -> OrderedDict[str, biblib.bib.Entry]:
 	with open(filename, 'r', encoding = 'utf-8') as f:
 		for line in f:
 			for typ  in BIBTEX_ENTRY_TYPES_LINESTART:
-				if line.startswith(typ):
-					all_keys.append(line.removeprefix(typ).split(',')[0])
+				if line.lower().startswith(typ):
+					all_keys.append(line.split('{')[1].split(',')[0])
 
 	# fix the keys in `db` with the matching correct-case keys in `all_keys`
 	assert len(all_keys) == len(db), f'manually read keys count doesnt match number of keys in database: {len(all_keys) = }\t{len(db) = }'


### PR DESCRIPTION
The bibtex entry types may contain uppercase letters, e.g. Jabref automatically capitalizes all bibtex entry types (e.g. Article instead of article). Biblib does not distinguish between upper and lower case letters for the bibtex entry types, but the function to get the correct keys for the case results in an error with uppercase letters in the bibtex entry types. 
I modified the function slightly to convert all uppercase letters to lower case for the bibtex entry type, but to preserve the bibtex key.